### PR TITLE
Update 04_energy.ipynb

### DIFF
--- a/chapter09_numoptim/04_energy.ipynb
+++ b/chapter09_numoptim/04_energy.ipynb
@@ -243,7 +243,7 @@
    "outputs": [],
    "source": [
     "P1 = opt.minimize(energy, P0.ravel(),\n",
-    "                  method='L-BFGS-B',\n",
+    "                  method='Powell',\n",
     "                  bounds=bounds).x.reshape((-1, 2))"
    ]
   },


### PR DESCRIPTION
It seems that the optimization method should be 'Powell', L-BFGS-B fails to find equilibrium configuration. When changing it to Powell, the program gives a solution that is displayed in rendered mode, and in the cookbook itself.
Tested on Python 3.8.5 64-bit, SciPy 1.5.2, and NumPy 1.19.2.